### PR TITLE
use the init_app style for use with app factory pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ def echo_status(status):
 The following metrics are exported by default
 (unless the `export_defaults` is set to `False`).
 
-- `flask_http_request_duration_seconds` (Histogram)  
-  Labels: `method`, `path` and `status`.  
+- `flask_http_request_duration_seconds` (Histogram)
+  Labels: `method`, `path` and `status`.
   Flask HTTP request duration in seconds for all Flask requests.
-- `flask_http_request_total` (Counter)  
+- `flask_http_request_total` (Counter)
   Labels: `method` and `status`.
   Total number of HTTP requests for all Flask requests.
-- `flask_exporter_info` (Gauge)  
+- `flask_exporter_info` (Gauge)
   Information about the Prometheus Flask exporter itself (e.g. `version`).
 
 ## Configuration
@@ -118,6 +118,10 @@ See some simple examples visualized on a Grafana dashboard by running
 the demo in the [examples/sample-signals](https://github.com/rycus86/prometheus_flask_exporter/tree/master/examples/wsgi) folder.
 
 ![Example dashboard](examples/sample-signals/dashboard.png)
+
+## App Factory Pattern
+
+This library also supports the flask [app factory pattern](http://flask.pocoo.org/docs/1.0/patterns/appfactories/). Use the `init_app` method to attach the library to one or more application objects.
 
 ## Debug mode
 

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -1,0 +1,34 @@
+from unittest_helper import BaseTestCase
+from prometheus_flask_exporter import PrometheusMetrics
+from prometheus_client import CollectorRegistry
+from flask import request, abort
+
+class AppFactoryTest(BaseTestCase):
+
+    def metrics_init(self, **kwargs):
+        registry = kwargs.pop('registry', CollectorRegistry(auto_describe=True))
+        metrics = PrometheusMetrics(registry=registry, **kwargs)
+        metrics.init_app(self.app)
+
+        return metrics
+
+    def test_restricted(self):
+        self.metrics_init()
+
+        @self.app.route('/test')
+        def test():
+            return 'OK'
+
+        self.client.get('/test')
+
+        response = self.client.get('/metrics')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get('/metrics?name[]=flask_exporter_info')
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get('/metrics'
+                                   '?name[]=flask_http_request_duration_seconds_bucket'
+                                   '&name[]=flask_http_request_duration_seconds_count'
+                                   '&name[]=flask_http_request_duration_seconds_sum')
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,7 +19,7 @@ class MetricsTest(BaseTestCase):
 
         @self.app.route('/test/2')
         @metrics.histogram('hist_2', 'Histogram 2', labels={
-            'uri': lambda: request.path, 
+            'uri': lambda: request.path,
             'code': lambda r: r.status_code
         })
         def test2():

--- a/tests/unittest_helper.py
+++ b/tests/unittest_helper.py
@@ -17,7 +17,6 @@ class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
         self.app.testing = True
-        self.app.app_context().push()
         self.client = self.app.test_client()
 
     def metrics(self, **kwargs):

--- a/tests/unittest_helper.py
+++ b/tests/unittest_helper.py
@@ -17,6 +17,7 @@ class BaseTestCase(unittest.TestCase):
     def setUp(self):
         self.app = Flask(__name__)
         self.app.testing = True
+        self.app.app_context().push()
         self.client = self.app.test_client()
 
     def metrics(self, **kwargs):


### PR DESCRIPTION
Hey,

I'd love to use this in my flask app, but we use the "app factory" pattern.  http://flask.pocoo.org/docs/0.12/extensiondev/#the-extension-code shows an example of this. I tried to do two things here:

1) Allow no `app` object to be passed to the constructor.
2) Use `current_app` instead of `self.app` (See the "Note on init_app" near the bottom of that linked section)

The `**kwargs` basically copying the constructor args might be a little awkward, but is there for backwards compatibility? Maybe? You could also scrap that, and just leave the constructor args, and `init_app` just take the `app` object.

In any case, if you're into this, or would like some changes, please let me know.