### PR TITLE
Allow empty prefixes for default metrics

### DIFF
--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -246,7 +246,7 @@ class PrometheusMetrics(object):
             duration_group_name = duration_group
 
         histogram = Histogram(
-            '%s_http_request_duration_seconds' % prefix,
+            '%shttp_request_duration_seconds' % prefix,
             'Flask HTTP request duration in seconds',
             ('method', duration_group_name, 'status'),
             registry=self.registry,
@@ -254,14 +254,14 @@ class PrometheusMetrics(object):
         )
 
         counter = Counter(
-            '%s_http_request_total' % prefix,
+            '%shttp_request_total' % prefix,
             'Total number of HTTP requests',
             ('method', 'status'),
             registry=self.registry
         )
 
         self.info(
-            '%s_exporter_info' % prefix,
+            '%sexporter_info' % prefix,
             'Information about the Prometheus Flask exporter',
             version=self.version
         )

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -67,7 +67,7 @@ class PrometheusMetrics(object):
     """
 
     def __init__(self, app, path='/metrics',
-                 export_defaults=True, defaults_prefix='flask',
+                 export_defaults=True, defaults_prefix='flask_',
                  group_by='path', buckets=None,
                  registry=DEFAULT_REGISTRY, **kwargs):
         """
@@ -91,7 +91,7 @@ class PrometheusMetrics(object):
         self.app = app
         self.path = path
         self._export_defaults = export_defaults
-        self._defaults_prefix = defaults_prefix or 'flask'
+        self._defaults_prefix = defaults_prefix
         self.buckets = buckets
         self.registry = registry
         self.version = __version__
@@ -198,7 +198,7 @@ class PrometheusMetrics(object):
         thread.start()
 
     def export_defaults(self, buckets=None, group_by='path',
-                        prefix='flask', app=None, **kwargs):
+                        prefix='flask_', app=None, **kwargs):
         """
         Export the default metrics:
             - HTTP request latencies
@@ -216,8 +216,8 @@ class PrometheusMetrics(object):
         if app is None:
             app = self.app or current_app
 
-        if not prefix:
-            prefix = self._defaults_prefix or 'flask'
+        if prefix is None:
+            prefix = self._defaults_prefix if self._defaults_prefix is None else 'flask_'
 
         # use the default buckets from prometheus_client if not given here
         buckets_as_kwargs = {}

--- a/prometheus_flask_exporter/multiprocess.py
+++ b/prometheus_flask_exporter/multiprocess.py
@@ -41,7 +41,7 @@ class MultiprocessPrometheusMetrics(PrometheusMetrics):
     __metaclass__ = ABCMeta
 
     def __init__(self, app=None, export_defaults=True,
-                 defaults_prefix='flask', group_by='path',
+                 defaults_prefix='flask_', group_by='path',
                  buckets=None, registry=None):
         """
         Create a new multiprocess-aware Prometheus metrics export configuration.

--- a/prometheus_flask_exporter/multiprocess.py
+++ b/prometheus_flask_exporter/multiprocess.py
@@ -41,7 +41,7 @@ class MultiprocessPrometheusMetrics(PrometheusMetrics):
     __metaclass__ = ABCMeta
 
     def __init__(self, app=None, export_defaults=True,
-                 defaults_prefix='flask_', group_by='path',
+                 defaults_prefix='flask', group_by='path',
                  buckets=None, registry=None):
         """
         Create a new multiprocess-aware Prometheus metrics export configuration.

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -149,7 +149,7 @@ class DefaultsTest(BaseTestCase):
         )
 
     def test_custom_defaults_prefix(self):
-        metrics = self.metrics(defaults_prefix='www')
+        metrics = self.metrics(defaults_prefix='www_')
 
         self.assertAbsent(
             'flask_exporter_info',
@@ -208,7 +208,7 @@ class DefaultsTest(BaseTestCase):
             ('method', 'GET'), ('status', 200)
         )
 
-        metrics.export_defaults(prefix='late')
+        metrics.export_defaults(prefix='late_')
 
         self.assertMetric(
             'late_exporter_info', '1.0',

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,5 +1,6 @@
 from unittest_helper import BaseTestCase
 
+from prometheus_flask_exporter import NO_PREFIX
 from flask import make_response
 
 
@@ -149,7 +150,7 @@ class DefaultsTest(BaseTestCase):
         )
 
     def test_custom_defaults_prefix(self):
-        metrics = self.metrics(defaults_prefix='www_')
+        metrics = self.metrics(defaults_prefix='www')
 
         self.assertAbsent(
             'flask_exporter_info',
@@ -177,6 +178,39 @@ class DefaultsTest(BaseTestCase):
         )
         self.assertMetric(
             'www_http_request_duration_seconds_count', '2.0',
+            ('method', 'GET'), ('path', '/test'), ('status', 200)
+        )
+
+    def test_no_defaults_prefix(self):
+        metrics = self.metrics(defaults_prefix=NO_PREFIX)
+
+        self.assertAbsent(
+            'flask_exporter_info',
+            ('version', metrics.version)
+        )
+        self.assertMetric(
+            'exporter_info', '1.0',
+            ('version', metrics.version)
+        )
+
+        @self.app.route('/test')
+        def test():
+            return 'OK'
+
+        self.client.get('/test')
+        self.client.get('/test')
+        self.client.get('/test')
+
+        self.assertAbsent(
+            'flask_http_request_total',
+            ('method', 'GET'), ('status', 200)
+        )
+        self.assertMetric(
+            'http_request_total', '3.0',
+            ('method', 'GET'), ('status', 200)
+        )
+        self.assertMetric(
+            'http_request_duration_seconds_count', '3.0',
             ('method', 'GET'), ('path', '/test'), ('status', 200)
         )
 
@@ -208,7 +242,7 @@ class DefaultsTest(BaseTestCase):
             ('method', 'GET'), ('status', 200)
         )
 
-        metrics.export_defaults(prefix='late_')
+        metrics.export_defaults(prefix='late')
 
         self.assertMetric(
             'late_exporter_info', '1.0',


### PR DESCRIPTION
Hey there!

I've just started using `prometheus_flask_exporter` and it does everything I want except allowing default metrics to not have prefix at all. The reason for that is that we are already exporting some metrics from other applications and we want them to have the same name if possible. Since those metrics are coming from different stacks/languages having `flask_` prefix is making this a bit problematic. I've modified the code to allow setting `defaults_prefix` to be empty string. It should not be a problem since all functions that deal with default metrics have sane defaults.

Let me know what you think about it.