### PR TITLE
ENH: _check_multiproc_env_var now checks for both upper and lowercase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.pyc
 .coverage
 coverage.xml
+.python-version
+__pycache__

--- a/prometheus_flask_exporter/multiprocess.py
+++ b/prometheus_flask_exporter/multiprocess.py
@@ -18,11 +18,12 @@ def _check_multiproc_env_var():
         or if it does not point to a directory
     """
 
-    if 'prometheus_multiproc_dir' in os.environ:
-        if os.path.isdir(os.environ['prometheus_multiproc_dir']):
-            return
+    prometheus_dir = os.getenv('prometheus_multiproc_dir') or os.getenv('PROMETHEUS_MULTIPROC_DIR')
+    if prometheus_dir and os.path.isdir(prometheus_dir):
+        return
 
-    raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
+    raise ValueError('env prometheus_multiproc_dir/PROMETHEUS_MULTIPROC_DIR '
+                     'is not set or not a directory')
 
 
 class MultiprocessPrometheusMetrics(PrometheusMetrics):

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,26 @@
+from unittest_helper import BaseTestCase
+import tempfile
+import shutil
+import os
+from prometheus_flask_exporter.multiprocess import _check_multiproc_env_var
+from unittest.mock import patch
+
+
+class TestEnvDir(BaseTestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+
+    def test_check_multiproc_env_var_works_with_lowercase(self):
+        with patch.dict(os.environ, {'prometheus_multiproc_dir': 'not_a_dir'}):
+            self.assertRaises(ValueError, _check_multiproc_env_var)
+        with patch.dict(os.environ, {"prometheus_multiproc_dir": self.temp_dir}):
+            self.assertIsNone(_check_multiproc_env_var())
+
+    def test_check_multiproc_env_var_works_with_uppercase(self):
+        with patch.dict(os.environ, {'PROMETHEUS_MULTIPROC_DIR': 'not_a_dir'}):
+            self.assertRaises(ValueError, _check_multiproc_env_var)
+        with patch.dict(os.environ, {"PROMETHEUS_MULTIPROC_DIR": self.temp_dir}):
+            self.assertIsNone(_check_multiproc_env_var())


### PR DESCRIPTION
It is common convention to uppercase environment variables, leading
to confused endusers when they think they have set the env correcly
not realizing it has to be lowercased.

This PR changes the function to check for both versions and adds tests