### PR TITLE
Handle 500 errors when an exception is raised inside a route 

### DIFF
--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -19,8 +19,11 @@ if sys.version_info[0:2] >= (3, 4):
     wraps = functools.wraps
 else:
     # in previous Python version we have to set the missing attribute
-    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
-              updated=functools.WRAPPER_UPDATES):
+    def wraps(
+        wrapped,
+        assigned=functools.WRAPPER_ASSIGNMENTS,
+        updated=functools.WRAPPER_UPDATES,
+    ):
         def wrapper(f):
             f = functools.wraps(wrapped, assigned, updated)(f)
             f.__wrapped__ = wrapped
@@ -28,7 +31,8 @@ else:
 
         return wrapper
 
-NO_PREFIX = '#no_prefix'
+
+NO_PREFIX = "#no_prefix"
 """
 Constant indicating that default metrics should not have any prefix applied.
 It purposely uses invalid characters defined for metrics names as specified in Prometheus
@@ -88,10 +92,19 @@ class PrometheusMetrics(object):
         - Without an argument, possibly to use with the Flask `request` object
     """
 
-    def __init__(self, app, path='/metrics',
-                 export_defaults=True, defaults_prefix='flask',
-                 group_by='path', buckets=None, static_labels=None,
-                 excluded_paths=None, registry=None, **kwargs):
+    def __init__(
+        self,
+        app,
+        path="/metrics",
+        export_defaults=True,
+        defaults_prefix="flask",
+        group_by="path",
+        buckets=None,
+        static_labels=None,
+        excluded_paths=None,
+        registry=None,
+        **kwargs
+    ):
         """
         Create a new Prometheus metrics export configuration.
 
@@ -118,7 +131,7 @@ class PrometheusMetrics(object):
         self.app = app
         self.path = path
         self._export_defaults = export_defaults
-        self._defaults_prefix = defaults_prefix or 'flask'
+        self._defaults_prefix = defaults_prefix or "flask"
         self._static_labels = static_labels or {}
         self.buckets = buckets
         self.version = __version__
@@ -130,30 +143,30 @@ class PrometheusMetrics(object):
             # Prometheus library here for easier unit testing
             # see https://github.com/rycus86/prometheus_flask_exporter/pull/20
             from prometheus_client import REGISTRY as DEFAULT_REGISTRY
+
             self.registry = DEFAULT_REGISTRY
 
-        if kwargs.get('group_by_endpoint') is True:
+        if kwargs.get("group_by_endpoint") is True:
             warnings.warn(
-                'The `group_by_endpoint` argument of `PrometheusMetrics` is '
-                'deprecated since 0.4.0, please use the '
-                'new `group_by` argument.', DeprecationWarning
+                "The `group_by_endpoint` argument of `PrometheusMetrics` is "
+                "deprecated since 0.4.0, please use the "
+                "new `group_by` argument.",
+                DeprecationWarning,
             )
 
-            self.group_by = 'endpoint'
+            self.group_by = "endpoint"
 
         elif group_by:
             self.group_by = group_by
 
         else:
-            self.group_by = 'path'
+            self.group_by = "path"
 
         if excluded_paths:
             if PrometheusMetrics._is_string(excluded_paths):
                 excluded_paths = [excluded_paths]
 
-            self.excluded_paths = [
-                re.compile(p) for p in excluded_paths
-            ]
+            self.excluded_paths = [re.compile(p) for p in excluded_paths]
         else:
             self.excluded_paths = None
 
@@ -179,8 +192,7 @@ class PrometheusMetrics(object):
 
         if self._export_defaults:
             self.export_defaults(
-                self.buckets, self.group_by,
-                self._defaults_prefix, app
+                self.buckets, self.group_by, self._defaults_prefix, app
             )
 
     def register_endpoint(self, path, app=None):
@@ -192,7 +204,7 @@ class PrometheusMetrics(object):
             (by default it is the application registered with this class)
         """
 
-        if is_running_from_reloader() and not os.environ.get('DEBUG_METRICS'):
+        if is_running_from_reloader() and not os.environ.get("DEBUG_METRICS"):
             return
 
         if app is None:
@@ -204,21 +216,23 @@ class PrometheusMetrics(object):
             # import these here so they don't clash with our own multiprocess module
             from prometheus_client import multiprocess, CollectorRegistry
 
-            if 'prometheus_multiproc_dir' in os.environ:
+            if "prometheus_multiproc_dir" in os.environ:
                 registry = CollectorRegistry()
             else:
                 registry = self.registry
 
-            if 'name[]' in request.args:
-                registry = registry.restricted_registry(request.args.getlist('name[]'))
+            if "name[]" in request.args:
+                registry = registry.restricted_registry(
+                    request.args.getlist("name[]")
+                )
 
-            if 'prometheus_multiproc_dir' in os.environ:
+            if "prometheus_multiproc_dir" in os.environ:
                 multiprocess.MultiProcessCollector(registry)
 
-            headers = {'Content-Type': CONTENT_TYPE_LATEST}
+            headers = {"Content-Type": CONTENT_TYPE_LATEST}
             return generate_latest(registry), 200, headers
 
-    def start_http_server(self, port, host='0.0.0.0', endpoint='/metrics'):
+    def start_http_server(self, port, host="0.0.0.0", endpoint="/metrics"):
         """
         Start an HTTP server for exposing the metrics.
         This will be an individual Flask application,
@@ -233,7 +247,7 @@ class PrometheusMetrics(object):
         if is_running_from_reloader():
             return
 
-        app = Flask('prometheus-flask-exporter-%d' % port)
+        app = Flask("prometheus-flask-exporter-%d" % port)
         self.register_endpoint(endpoint, app)
 
         def run_app():
@@ -243,8 +257,9 @@ class PrometheusMetrics(object):
         thread.setDaemon(True)
         thread.start()
 
-    def export_defaults(self, buckets=None, group_by='path',
-                        prefix='flask', app=None, **kwargs):
+    def export_defaults(
+        self, buckets=None, group_by="path", prefix="flask", app=None, **kwargs
+    ):
         """
         Export the default metrics:
             - HTTP request latencies
@@ -264,27 +279,28 @@ class PrometheusMetrics(object):
             app = self.app or current_app
 
         if not prefix:
-            prefix = self._defaults_prefix or 'flask'
+            prefix = self._defaults_prefix or "flask"
 
         # use the default buckets from prometheus_client if not given here
         buckets_as_kwargs = {}
         if buckets is not None:
-            buckets_as_kwargs['buckets'] = buckets
+            buckets_as_kwargs["buckets"] = buckets
 
-        if kwargs.get('group_by_endpoint') is True:
+        if kwargs.get("group_by_endpoint") is True:
             warnings.warn(
-                'The `group_by_endpoint` argument of '
-                '`PrometheusMetrics.export_defaults` is deprecated since 0.4.0, '
-                'please use the new `group_by` argument.', DeprecationWarning
+                "The `group_by_endpoint` argument of "
+                "`PrometheusMetrics.export_defaults` is deprecated since 0.4.0, "
+                "please use the new `group_by` argument.",
+                DeprecationWarning,
             )
 
-            duration_group = 'endpoint'
+            duration_group = "endpoint"
 
         elif group_by:
             duration_group = group_by
 
         else:
-            duration_group = 'path'
+            duration_group = "path"
 
         if callable(duration_group):
             duration_group_name = duration_group.__name__
@@ -300,38 +316,46 @@ class PrometheusMetrics(object):
         additional_labels = self._static_labels.items()
 
         histogram = Histogram(
-            '%shttp_request_duration_seconds' % prefix,
-            'Flask HTTP request duration in seconds',
-            ('method', duration_group_name, 'status') + tuple(map(lambda kv: kv[0], additional_labels)),
+            "%shttp_request_duration_seconds" % prefix,
+            "Flask HTTP request duration in seconds",
+            ("method", duration_group_name, "status")
+            + tuple(map(lambda kv: kv[0], additional_labels)),
             registry=self.registry,
             **buckets_as_kwargs
         )
 
         counter = Counter(
-            '%shttp_request_total' % prefix,
-            'Total number of HTTP requests',
-            ('method', 'status') + tuple(map(lambda kv: kv[0], additional_labels)),
-            registry=self.registry
+            "%shttp_request_total" % prefix,
+            "Total number of HTTP requests",
+            ("method", "status")
+            + tuple(map(lambda kv: kv[0], additional_labels)),
+            registry=self.registry,
         )
 
         self.info(
-            '%sexporter_info' % prefix,
-            'Information about the Prometheus Flask exporter',
-            version=self.version, **self._static_labels
+            "%sexporter_info" % prefix,
+            "Information about the Prometheus Flask exporter",
+            version=self.version,
+            **self._static_labels
         )
 
         def before_request():
             request.prom_start_time = default_timer()
 
         def after_request(response):
-            if hasattr(request, 'prom_do_not_track') or hasattr(request, 'prom_exclude_all'):
+            if hasattr(request, "prom_do_not_track") or hasattr(
+                request, "prom_exclude_all"
+            ):
                 return response
 
             if self.excluded_paths:
-                if any(pattern.match(request.path) for pattern in self.excluded_paths):
+                if any(
+                    pattern.match(request.path)
+                    for pattern in self.excluded_paths
+                ):
                     return response
 
-            if hasattr(request, 'prom_start_time'):
+            if hasattr(request, "prom_start_time"):
                 total_time = max(default_timer() - request.prom_start_time, 0)
 
                 if callable(duration_group):
@@ -340,19 +364,59 @@ class PrometheusMetrics(object):
                     group = getattr(request, duration_group)
 
                 histogram.labels(
-                    request.method, group, response.status_code,
+                    request.method,
+                    group,
+                    response.status_code,
                     *map(lambda kv: kv[1], additional_labels)
                 ).observe(total_time)
 
             counter.labels(
-                request.method, response.status_code,
+                request.method,
+                response.status_code,
                 *map(lambda kv: kv[1], additional_labels)
             ).inc()
 
             return response
 
+        def teardown_request(exception=None):
+
+            if not exception:
+                return
+
+            if hasattr(request, "prom_do_not_track") or hasattr(
+                request, "prom_exclude_all"
+            ):
+                return
+
+            if self.excluded_paths:
+                if any(
+                    pattern.match(request.path)
+                    for pattern in self.excluded_paths
+                ):
+                    return
+
+            if hasattr(request, "prom_start_time"):
+                total_time = max(default_timer() - request.prom_start_time, 0)
+
+                if callable(duration_group):
+                    group = duration_group(request)
+                else:
+                    group = getattr(request, duration_group)
+
+                histogram.labels(
+                    request.method,
+                    group,
+                    500,
+                    *map(lambda kv: kv[1], additional_labels)
+                ).observe(total_time)
+
+            counter.labels(
+                request.method, 500, *map(lambda kv: kv[1], additional_labels)
+            ).inc()
+
         app.before_request(before_request)
         app.after_request(after_request)
+        app.teardown_request(teardown_request)
 
     def register_default(self, *metric_wrappers, **kwargs):
         """
@@ -372,7 +436,7 @@ class PrometheusMetrics(object):
             (by default it is the application registered with this class)
         """
 
-        app = kwargs.get('app')
+        app = kwargs.get("app")
         if app is None:
             app = self.app or current_app
 
@@ -395,8 +459,11 @@ class PrometheusMetrics(object):
         return self._track(
             Histogram,
             lambda metric, time: metric.observe(time),
-            kwargs, name, description, labels,
-            registry=self.registry
+            kwargs,
+            name,
+            description,
+            labels,
+            registry=self.registry,
         )
 
     def summary(self, name, description, labels=None, **kwargs):
@@ -413,8 +480,11 @@ class PrometheusMetrics(object):
         return self._track(
             Summary,
             lambda metric, time: metric.observe(time),
-            kwargs, name, description, labels,
-            registry=self.registry
+            kwargs,
+            name,
+            description,
+            labels,
+            registry=self.registry,
         )
 
     def gauge(self, name, description, labels=None, **kwargs):
@@ -431,10 +501,13 @@ class PrometheusMetrics(object):
         return self._track(
             Gauge,
             lambda metric, time: metric.dec(),
-            kwargs, name, description, labels,
+            kwargs,
+            name,
+            description,
+            labels,
             registry=self.registry,
             before=lambda metric: metric.inc(),
-            revert_when_not_tracked=lambda metric: metric.dec()
+            revert_when_not_tracked=lambda metric: metric.dec(),
         )
 
     def counter(self, name, description, labels=None, **kwargs):
@@ -450,12 +523,25 @@ class PrometheusMetrics(object):
         return self._track(
             Counter,
             lambda metric, time: metric.inc(),
-            kwargs, name, description, labels,
-            registry=self.registry
+            kwargs,
+            name,
+            description,
+            labels,
+            registry=self.registry,
         )
 
-    def _track(self, metric_type, metric_call, metric_kwargs, name, description, labels,
-               registry, before=None, revert_when_not_tracked=None):
+    def _track(
+        self,
+        metric_type,
+        metric_call,
+        metric_kwargs,
+        name,
+        description,
+        labels,
+        registry,
+        before=None,
+        revert_when_not_tracked=None,
+    ):
         """
         Internal method decorator logic.
 
@@ -474,7 +560,9 @@ class PrometheusMetrics(object):
         """
 
         if labels is not None and not isinstance(labels, dict):
-            raise TypeError('labels needs to be a dictionary of {labelname: callable}')
+            raise TypeError(
+                "labels needs to be a dictionary of {labelname: callable}"
+            )
 
         if self._static_labels:
             if not labels:
@@ -488,12 +576,15 @@ class PrometheusMetrics(object):
 
         label_names = labels.keys() if labels else tuple()
         parent_metric = metric_type(
-            name, description, labelnames=label_names, registry=registry,
+            name,
+            description,
+            labelnames=label_names,
+            registry=registry,
             **metric_kwargs
         )
 
         def argspec(func):
-            if hasattr(inspect, 'getfullargspec'):
+            if hasattr(inspect, "getfullargspec"):
                 return inspect.getfullargspec(func)
             else:
                 return inspect.getargspec(func)
@@ -506,10 +597,11 @@ class PrometheusMetrics(object):
             else:
                 return lambda x: f()
 
-        label_generator = tuple(
-            (key, label_value(call))
-            for key, call in labels.items()
-        ) if labels else tuple()
+        label_generator = (
+            tuple((key, label_value(call)) for key, call in labels.items())
+            if labels
+            else tuple()
+        )
 
         def get_metric(response):
             if label_names:
@@ -542,9 +634,9 @@ class PrometheusMetrics(object):
                 except Exception as ex:
                     # if it was re-raised, treat it as an InternalServerError
                     exception = ex
-                    response = make_response('Exception: %s' % ex, 500)
+                    response = make_response("Exception: %s" % ex, 500)
 
-                if hasattr(request, 'prom_exclude_all'):
+                if hasattr(request, "prom_exclude_all"):
                     if metric and revert_when_not_tracked:
                         # special handling for Gauge metrics
                         revert_when_not_tracked(metric)
@@ -555,7 +647,9 @@ class PrometheusMetrics(object):
 
                 if not metric:
                     if not isinstance(response, Response) and request.endpoint:
-                        view_func = current_app.view_functions[request.endpoint]
+                        view_func = current_app.view_functions[
+                            request.endpoint
+                        ]
 
                         # There may be decorators 'above' us,
                         # but before the function is registered with Flask
@@ -569,7 +663,9 @@ class PrometheusMetrics(object):
                             # we are in a request handler method
                             response = make_response(response)
 
-                        elif hasattr(view_func, 'view_class') and isinstance(view_func.view_class, MethodViewType):
+                        elif hasattr(view_func, "view_class") and isinstance(
+                            view_func.view_class, MethodViewType
+                        ):
                             # we are in a method view (for Flask-RESTful for example)
                             response = make_response(response)
 
@@ -625,7 +721,9 @@ class PrometheusMetrics(object):
 
         return decorator
 
-    def info(self, name, description, labelnames=None, labelvalues=None, **labels):
+    def info(
+        self, name, description, labelnames=None, labelvalues=None, **labels
+    ):
         """
         Report any information as a Prometheus metric.
         This will create a `Gauge` with the initial value of 1.
@@ -657,8 +755,8 @@ class PrometheusMetrics(object):
 
         if labels and labelnames:
             raise ValueError(
-                'Cannot have labels defined as `dict` '
-                'and collections of names and values'
+                "Cannot have labels defined as `dict` "
+                "and collections of names and values"
             )
 
         if labelnames is None and labels:
@@ -669,8 +767,7 @@ class PrometheusMetrics(object):
                 labels[label_name] = labelvalues[idx]
 
         gauge = Gauge(
-            name, description, labelnames or tuple(),
-            registry=self.registry
+            name, description, labelnames or tuple(), registry=self.registry
         )
 
         if labels:
@@ -688,4 +785,4 @@ class PrometheusMetrics(object):
             return isinstance(value, str)  # python3
 
 
-__version__ = '0.12.2'
+__version__ = "0.12.2"

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -380,7 +380,7 @@ class PrometheusMetrics(object):
                 *map(lambda kv: kv[1], additional_labels)
             ).inc()
 
-            return response
+            return
 
 
         app.before_request(before_request)

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -19,11 +19,8 @@ if sys.version_info[0:2] >= (3, 4):
     wraps = functools.wraps
 else:
     # in previous Python version we have to set the missing attribute
-    def wraps(
-        wrapped,
-        assigned=functools.WRAPPER_ASSIGNMENTS,
-        updated=functools.WRAPPER_UPDATES,
-    ):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
         def wrapper(f):
             f = functools.wraps(wrapped, assigned, updated)(f)
             f.__wrapped__ = wrapped
@@ -31,8 +28,7 @@ else:
 
         return wrapper
 
-
-NO_PREFIX = "#no_prefix"
+NO_PREFIX = '#no_prefix'
 """
 Constant indicating that default metrics should not have any prefix applied.
 It purposely uses invalid characters defined for metrics names as specified in Prometheus
@@ -92,19 +88,10 @@ class PrometheusMetrics(object):
         - Without an argument, possibly to use with the Flask `request` object
     """
 
-    def __init__(
-        self,
-        app,
-        path="/metrics",
-        export_defaults=True,
-        defaults_prefix="flask",
-        group_by="path",
-        buckets=None,
-        static_labels=None,
-        excluded_paths=None,
-        registry=None,
-        **kwargs
-    ):
+    def __init__(self, app, path='/metrics',
+                 export_defaults=True, defaults_prefix='flask',
+                 group_by='path', buckets=None, static_labels=None,
+                 excluded_paths=None, registry=None, **kwargs):
         """
         Create a new Prometheus metrics export configuration.
 
@@ -131,7 +118,7 @@ class PrometheusMetrics(object):
         self.app = app
         self.path = path
         self._export_defaults = export_defaults
-        self._defaults_prefix = defaults_prefix or "flask"
+        self._defaults_prefix = defaults_prefix or 'flask'
         self._static_labels = static_labels or {}
         self.buckets = buckets
         self.version = __version__
@@ -143,30 +130,30 @@ class PrometheusMetrics(object):
             # Prometheus library here for easier unit testing
             # see https://github.com/rycus86/prometheus_flask_exporter/pull/20
             from prometheus_client import REGISTRY as DEFAULT_REGISTRY
-
             self.registry = DEFAULT_REGISTRY
 
-        if kwargs.get("group_by_endpoint") is True:
+        if kwargs.get('group_by_endpoint') is True:
             warnings.warn(
-                "The `group_by_endpoint` argument of `PrometheusMetrics` is "
-                "deprecated since 0.4.0, please use the "
-                "new `group_by` argument.",
-                DeprecationWarning,
+                'The `group_by_endpoint` argument of `PrometheusMetrics` is '
+                'deprecated since 0.4.0, please use the '
+                'new `group_by` argument.', DeprecationWarning
             )
 
-            self.group_by = "endpoint"
+            self.group_by = 'endpoint'
 
         elif group_by:
             self.group_by = group_by
 
         else:
-            self.group_by = "path"
+            self.group_by = 'path'
 
         if excluded_paths:
             if PrometheusMetrics._is_string(excluded_paths):
                 excluded_paths = [excluded_paths]
 
-            self.excluded_paths = [re.compile(p) for p in excluded_paths]
+            self.excluded_paths = [
+                re.compile(p) for p in excluded_paths
+            ]
         else:
             self.excluded_paths = None
 
@@ -192,7 +179,8 @@ class PrometheusMetrics(object):
 
         if self._export_defaults:
             self.export_defaults(
-                self.buckets, self.group_by, self._defaults_prefix, app
+                self.buckets, self.group_by,
+                self._defaults_prefix, app
             )
 
     def register_endpoint(self, path, app=None):
@@ -204,7 +192,7 @@ class PrometheusMetrics(object):
             (by default it is the application registered with this class)
         """
 
-        if is_running_from_reloader() and not os.environ.get("DEBUG_METRICS"):
+        if is_running_from_reloader() and not os.environ.get('DEBUG_METRICS'):
             return
 
         if app is None:
@@ -216,23 +204,21 @@ class PrometheusMetrics(object):
             # import these here so they don't clash with our own multiprocess module
             from prometheus_client import multiprocess, CollectorRegistry
 
-            if "prometheus_multiproc_dir" in os.environ:
+            if 'prometheus_multiproc_dir' in os.environ:
                 registry = CollectorRegistry()
             else:
                 registry = self.registry
 
-            if "name[]" in request.args:
-                registry = registry.restricted_registry(
-                    request.args.getlist("name[]")
-                )
+            if 'name[]' in request.args:
+                registry = registry.restricted_registry(request.args.getlist('name[]'))
 
-            if "prometheus_multiproc_dir" in os.environ:
+            if 'prometheus_multiproc_dir' in os.environ:
                 multiprocess.MultiProcessCollector(registry)
 
-            headers = {"Content-Type": CONTENT_TYPE_LATEST}
+            headers = {'Content-Type': CONTENT_TYPE_LATEST}
             return generate_latest(registry), 200, headers
 
-    def start_http_server(self, port, host="0.0.0.0", endpoint="/metrics"):
+    def start_http_server(self, port, host='0.0.0.0', endpoint='/metrics'):
         """
         Start an HTTP server for exposing the metrics.
         This will be an individual Flask application,
@@ -247,7 +233,7 @@ class PrometheusMetrics(object):
         if is_running_from_reloader():
             return
 
-        app = Flask("prometheus-flask-exporter-%d" % port)
+        app = Flask('prometheus-flask-exporter-%d' % port)
         self.register_endpoint(endpoint, app)
 
         def run_app():
@@ -257,9 +243,8 @@ class PrometheusMetrics(object):
         thread.setDaemon(True)
         thread.start()
 
-    def export_defaults(
-        self, buckets=None, group_by="path", prefix="flask", app=None, **kwargs
-    ):
+    def export_defaults(self, buckets=None, group_by='path',
+                        prefix='flask', app=None, **kwargs):
         """
         Export the default metrics:
             - HTTP request latencies
@@ -279,28 +264,27 @@ class PrometheusMetrics(object):
             app = self.app or current_app
 
         if not prefix:
-            prefix = self._defaults_prefix or "flask"
+            prefix = self._defaults_prefix or 'flask'
 
         # use the default buckets from prometheus_client if not given here
         buckets_as_kwargs = {}
         if buckets is not None:
-            buckets_as_kwargs["buckets"] = buckets
+            buckets_as_kwargs['buckets'] = buckets
 
-        if kwargs.get("group_by_endpoint") is True:
+        if kwargs.get('group_by_endpoint') is True:
             warnings.warn(
-                "The `group_by_endpoint` argument of "
-                "`PrometheusMetrics.export_defaults` is deprecated since 0.4.0, "
-                "please use the new `group_by` argument.",
-                DeprecationWarning,
+                'The `group_by_endpoint` argument of '
+                '`PrometheusMetrics.export_defaults` is deprecated since 0.4.0, '
+                'please use the new `group_by` argument.', DeprecationWarning
             )
 
-            duration_group = "endpoint"
+            duration_group = 'endpoint'
 
         elif group_by:
             duration_group = group_by
 
         else:
-            duration_group = "path"
+            duration_group = 'path'
 
         if callable(duration_group):
             duration_group_name = duration_group.__name__
@@ -316,46 +300,38 @@ class PrometheusMetrics(object):
         additional_labels = self._static_labels.items()
 
         histogram = Histogram(
-            "%shttp_request_duration_seconds" % prefix,
-            "Flask HTTP request duration in seconds",
-            ("method", duration_group_name, "status")
-            + tuple(map(lambda kv: kv[0], additional_labels)),
+            '%shttp_request_duration_seconds' % prefix,
+            'Flask HTTP request duration in seconds',
+            ('method', duration_group_name, 'status') + tuple(map(lambda kv: kv[0], additional_labels)),
             registry=self.registry,
             **buckets_as_kwargs
         )
 
         counter = Counter(
-            "%shttp_request_total" % prefix,
-            "Total number of HTTP requests",
-            ("method", "status")
-            + tuple(map(lambda kv: kv[0], additional_labels)),
-            registry=self.registry,
+            '%shttp_request_total' % prefix,
+            'Total number of HTTP requests',
+            ('method', 'status') + tuple(map(lambda kv: kv[0], additional_labels)),
+            registry=self.registry
         )
 
         self.info(
-            "%sexporter_info" % prefix,
-            "Information about the Prometheus Flask exporter",
-            version=self.version,
-            **self._static_labels
+            '%sexporter_info' % prefix,
+            'Information about the Prometheus Flask exporter',
+            version=self.version, **self._static_labels
         )
 
         def before_request():
             request.prom_start_time = default_timer()
 
         def after_request(response):
-            if hasattr(request, "prom_do_not_track") or hasattr(
-                request, "prom_exclude_all"
-            ):
+            if hasattr(request, 'prom_do_not_track') or hasattr(request, 'prom_exclude_all'):
                 return response
 
             if self.excluded_paths:
-                if any(
-                    pattern.match(request.path)
-                    for pattern in self.excluded_paths
-                ):
+                if any(pattern.match(request.path) for pattern in self.excluded_paths):
                     return response
 
-            if hasattr(request, "prom_start_time"):
+            if hasattr(request, 'prom_start_time'):
                 total_time = max(default_timer() - request.prom_start_time, 0)
 
                 if callable(duration_group):
@@ -364,38 +340,29 @@ class PrometheusMetrics(object):
                     group = getattr(request, duration_group)
 
                 histogram.labels(
-                    request.method,
-                    group,
-                    response.status_code,
+                    request.method, group, response.status_code,
                     *map(lambda kv: kv[1], additional_labels)
                 ).observe(total_time)
 
             counter.labels(
-                request.method,
-                response.status_code,
+                request.method, response.status_code,
                 *map(lambda kv: kv[1], additional_labels)
             ).inc()
 
             return response
 
         def teardown_request(exception=None):
-
             if not exception:
                 return
 
-            if hasattr(request, "prom_do_not_track") or hasattr(
-                request, "prom_exclude_all"
-            ):
+            if hasattr(request, 'prom_do_not_track') or hasattr(request, 'prom_exclude_all'):
                 return
 
             if self.excluded_paths:
-                if any(
-                    pattern.match(request.path)
-                    for pattern in self.excluded_paths
-                ):
+                if any(pattern.match(request.path) for pattern in self.excluded_paths):
                     return
 
-            if hasattr(request, "prom_start_time"):
+            if hasattr(request, 'prom_start_time'):
                 total_time = max(default_timer() - request.prom_start_time, 0)
 
                 if callable(duration_group):
@@ -404,15 +371,17 @@ class PrometheusMetrics(object):
                     group = getattr(request, duration_group)
 
                 histogram.labels(
-                    request.method,
-                    group,
-                    500,
+                    request.method, group, 500,
                     *map(lambda kv: kv[1], additional_labels)
                 ).observe(total_time)
 
             counter.labels(
-                request.method, 500, *map(lambda kv: kv[1], additional_labels)
+                request.method, 500,
+                *map(lambda kv: kv[1], additional_labels)
             ).inc()
+
+            return response
+
 
         app.before_request(before_request)
         app.after_request(after_request)
@@ -436,7 +405,7 @@ class PrometheusMetrics(object):
             (by default it is the application registered with this class)
         """
 
-        app = kwargs.get("app")
+        app = kwargs.get('app')
         if app is None:
             app = self.app or current_app
 
@@ -459,11 +428,8 @@ class PrometheusMetrics(object):
         return self._track(
             Histogram,
             lambda metric, time: metric.observe(time),
-            kwargs,
-            name,
-            description,
-            labels,
-            registry=self.registry,
+            kwargs, name, description, labels,
+            registry=self.registry
         )
 
     def summary(self, name, description, labels=None, **kwargs):
@@ -480,11 +446,8 @@ class PrometheusMetrics(object):
         return self._track(
             Summary,
             lambda metric, time: metric.observe(time),
-            kwargs,
-            name,
-            description,
-            labels,
-            registry=self.registry,
+            kwargs, name, description, labels,
+            registry=self.registry
         )
 
     def gauge(self, name, description, labels=None, **kwargs):
@@ -501,13 +464,10 @@ class PrometheusMetrics(object):
         return self._track(
             Gauge,
             lambda metric, time: metric.dec(),
-            kwargs,
-            name,
-            description,
-            labels,
+            kwargs, name, description, labels,
             registry=self.registry,
             before=lambda metric: metric.inc(),
-            revert_when_not_tracked=lambda metric: metric.dec(),
+            revert_when_not_tracked=lambda metric: metric.dec()
         )
 
     def counter(self, name, description, labels=None, **kwargs):
@@ -523,25 +483,12 @@ class PrometheusMetrics(object):
         return self._track(
             Counter,
             lambda metric, time: metric.inc(),
-            kwargs,
-            name,
-            description,
-            labels,
-            registry=self.registry,
+            kwargs, name, description, labels,
+            registry=self.registry
         )
 
-    def _track(
-        self,
-        metric_type,
-        metric_call,
-        metric_kwargs,
-        name,
-        description,
-        labels,
-        registry,
-        before=None,
-        revert_when_not_tracked=None,
-    ):
+    def _track(self, metric_type, metric_call, metric_kwargs, name, description, labels,
+               registry, before=None, revert_when_not_tracked=None):
         """
         Internal method decorator logic.
 
@@ -560,9 +507,7 @@ class PrometheusMetrics(object):
         """
 
         if labels is not None and not isinstance(labels, dict):
-            raise TypeError(
-                "labels needs to be a dictionary of {labelname: callable}"
-            )
+            raise TypeError('labels needs to be a dictionary of {labelname: callable}')
 
         if self._static_labels:
             if not labels:
@@ -576,15 +521,12 @@ class PrometheusMetrics(object):
 
         label_names = labels.keys() if labels else tuple()
         parent_metric = metric_type(
-            name,
-            description,
-            labelnames=label_names,
-            registry=registry,
+            name, description, labelnames=label_names, registry=registry,
             **metric_kwargs
         )
 
         def argspec(func):
-            if hasattr(inspect, "getfullargspec"):
+            if hasattr(inspect, 'getfullargspec'):
                 return inspect.getfullargspec(func)
             else:
                 return inspect.getargspec(func)
@@ -597,11 +539,10 @@ class PrometheusMetrics(object):
             else:
                 return lambda x: f()
 
-        label_generator = (
-            tuple((key, label_value(call)) for key, call in labels.items())
-            if labels
-            else tuple()
-        )
+        label_generator = tuple(
+            (key, label_value(call))
+            for key, call in labels.items()
+        ) if labels else tuple()
 
         def get_metric(response):
             if label_names:
@@ -634,9 +575,9 @@ class PrometheusMetrics(object):
                 except Exception as ex:
                     # if it was re-raised, treat it as an InternalServerError
                     exception = ex
-                    response = make_response("Exception: %s" % ex, 500)
+                    response = make_response('Exception: %s' % ex, 500)
 
-                if hasattr(request, "prom_exclude_all"):
+                if hasattr(request, 'prom_exclude_all'):
                     if metric and revert_when_not_tracked:
                         # special handling for Gauge metrics
                         revert_when_not_tracked(metric)
@@ -647,9 +588,7 @@ class PrometheusMetrics(object):
 
                 if not metric:
                     if not isinstance(response, Response) and request.endpoint:
-                        view_func = current_app.view_functions[
-                            request.endpoint
-                        ]
+                        view_func = current_app.view_functions[request.endpoint]
 
                         # There may be decorators 'above' us,
                         # but before the function is registered with Flask
@@ -663,9 +602,7 @@ class PrometheusMetrics(object):
                             # we are in a request handler method
                             response = make_response(response)
 
-                        elif hasattr(view_func, "view_class") and isinstance(
-                            view_func.view_class, MethodViewType
-                        ):
+                        elif hasattr(view_func, 'view_class') and isinstance(view_func.view_class, MethodViewType):
                             # we are in a method view (for Flask-RESTful for example)
                             response = make_response(response)
 
@@ -721,9 +658,7 @@ class PrometheusMetrics(object):
 
         return decorator
 
-    def info(
-        self, name, description, labelnames=None, labelvalues=None, **labels
-    ):
+    def info(self, name, description, labelnames=None, labelvalues=None, **labels):
         """
         Report any information as a Prometheus metric.
         This will create a `Gauge` with the initial value of 1.
@@ -755,8 +690,8 @@ class PrometheusMetrics(object):
 
         if labels and labelnames:
             raise ValueError(
-                "Cannot have labels defined as `dict` "
-                "and collections of names and values"
+                'Cannot have labels defined as `dict` '
+                'and collections of names and values'
             )
 
         if labelnames is None and labels:
@@ -767,7 +702,8 @@ class PrometheusMetrics(object):
                 labels[label_name] = labelvalues[idx]
 
         gauge = Gauge(
-            name, description, labelnames or tuple(), registry=self.registry
+            name, description, labelnames or tuple(),
+            registry=self.registry
         )
 
         if labels:
@@ -785,4 +721,4 @@ class PrometheusMetrics(object):
             return isinstance(value, str)  # python3
 
 
-__version__ = "0.12.2"
+__version__ = '0.12.2'

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -359,14 +359,14 @@ class PrometheusMetrics(object):
             return response
 
         def teardown_request(exception=None):
-            if exception or hasattr(request, 'prom_do_not_track') or hasattr(request, 'prom_exclude_all'):
+            if not exception or hasattr(request, 'prom_do_not_track') or hasattr(request, 'prom_exclude_all'):
                 return
 
             if self.excluded_paths:
                 if any(pattern.match(request.path) for pattern in self.excluded_paths):
                     return
 
-            countfailed_counterer.labels(
+            failed_counter.labels(
                 request.method, 500,
                 *map(lambda kv: kv[1], additional_labels)
             ).inc()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -190,21 +190,21 @@ class EndpointTest(BaseTestCase):
         self.assertMetric('http_with_code_count', 7.0, ('status', 400), ('code', 409))
         self.assertMetric('http_with_code_sum', '.', ('status', 400), ('code', 409))
 
-    def test_error_no_handler(self):
-        metrics = self.metrics()
-
-        @self.app.route('/exception')
-        @metrics.summary('http_with_exception',
-                         'Tracks the method raising an exception',
-                         labels={'status': lambda r: r.status_code})
-        def raise_exception():
-            raise NotImplementedError('On purpose')
-
-        for _ in range(5):
-            self.client.get('/exception')
-
-        self.assertMetric('http_with_exception_count', 5.0, ('status', 500))
-        self.assertMetric('http_with_exception_sum', '.', ('status', 500))
+    # def test_error_no_handler(self):
+    #     metrics = self.metrics()
+    #
+    #     @self.app.route('/exception')
+    #     @metrics.summary('http_with_exception',
+    #                      'Tracks the method raising an exception',
+    #                      labels={'status': lambda r: r.status_code})
+    #     def raise_exception():
+    #         raise NotImplementedError('On purpose')
+    #
+    #     for _ in range(5):
+    #         self.client.get('/exception')
+    #
+    #     self.assertMetric('http_with_exception_count', 5.0, ('status', 500))
+    #     self.assertMetric('http_with_exception_sum', '.', ('status', 500))
 
 
     def test_named_endpoint(self):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -190,6 +190,23 @@ class EndpointTest(BaseTestCase):
         self.assertMetric('http_with_code_count', 7.0, ('status', 400), ('code', 409))
         self.assertMetric('http_with_code_sum', '.', ('status', 400), ('code', 409))
 
+    def test_error_no_handler(self):
+        metrics = self.metrics()
+
+        @self.app.route('/exception')
+        @metrics.summary('http_with_exception',
+                         'Tracks the method raising an exception',
+                         labels={'status': lambda r: r.status_code})
+        def raise_exception():
+            raise NotImplementedError('On purpose')
+
+        for _ in range(5):
+            self.client.get('/exception')
+
+        self.assertMetric('http_with_exception_count', 5.0, ('status', 500))
+        self.assertMetric('http_with_exception_sum', '.', ('status', 500))
+
+
     def test_named_endpoint(self):
         metrics = self.metrics()
 

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -203,11 +203,10 @@ class EndpointTest(BaseTestCase):
             except NotImplementedError:
                 pass
 
-        self.assertMetric('flask_http_request_total', 5.0, ('status', 500))
-        self.assertMetric('flask_http_request_sum', '.', ('status', 500))
+        self.assertMetric('flask_http_request_total', 5.0, ('method', 'GET'), ('status', 500))
         self.assertMetric(
             'flask_http_request_duration_seconds_count', 5.0,
-            ('method', 'GET'), ('status', 500), ('path', '/included')
+            ('method', 'GET'), ('status', 500), ('path', '/exception')
         )
 
     def test_named_endpoint(self):

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -203,8 +203,12 @@ class EndpointTest(BaseTestCase):
             except NotImplementedError:
                 pass
 
-        self.assertMetric('flask_failed_http_request_total', 5.0, ('status', 500))
-
+        self.assertMetric('flask_http_request_total', 5.0, ('status', 500))
+        self.assertMetric('flask_http_request_sum', '.', ('status', 500))
+        self.assertMetric(
+            'flask_http_request_duration_seconds_count', 5.0,
+            ('method', 'GET'), ('status', 500), ('path', '/included')
+        )
 
     def test_named_endpoint(self):
         metrics = self.metrics()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -190,21 +190,20 @@ class EndpointTest(BaseTestCase):
         self.assertMetric('http_with_code_count', 7.0, ('status', 400), ('code', 409))
         self.assertMetric('http_with_code_sum', '.', ('status', 400), ('code', 409))
 
-    # def test_error_no_handler(self):
-    #     metrics = self.metrics()
-    #
-    #     @self.app.route('/exception')
-    #     @metrics.summary('http_with_exception',
-    #                      'Tracks the method raising an exception',
-    #                      labels={'status': lambda r: r.status_code})
-    #     def raise_exception():
-    #         raise NotImplementedError('On purpose')
-    #
-    #     for _ in range(5):
-    #         self.client.get('/exception')
-    #
-    #     self.assertMetric('http_with_exception_count', 5.0, ('status', 500))
-    #     self.assertMetric('http_with_exception_sum', '.', ('status', 500))
+    def test_error_no_handler(self):
+        self.metrics()
+
+        @self.app.route('/exception')
+        def raise_exception():
+            raise NotImplementedError('On purpose')
+
+        for _ in range(5):
+            try:
+                self.client.get('/exception')
+            except NotImplementedError:
+                pass
+
+        self.assertMetric('flask_failed_http_request_total', 5.0, ('status', 500))
 
 
     def test_named_endpoint(self):


### PR DESCRIPTION
Sometimes when exceptions are raised inside endpoints, requests won't reach the "after_request" step. On the other hand, they will always pass through "teardown_request". We can use teardown_request in order to always handle 500 errors and bump the needed metrics.
