### PR TITLE
break down dataclasses to dicts

### DIFF
--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import re
 import sys
@@ -623,6 +624,15 @@ class PrometheusMetrics(object):
                                 view_func = view_func.__wrapped__
                             except AttributeError:
                                 break
+
+                        # Breaks dataclass/list of dataclass down to dict/dicts.
+                        if dataclasses.is_dataclass(response):
+                            response = dataclasses.asdict(response[0]), 200
+                        if isinstance(response, tuple):
+                            if dataclasses.is_dataclass(response[0]):
+                                response = dataclasses.asdict(response[0]), response[1]
+                            elif isinstance(response[0], list) and dataclasses.is_dataclass(response[0][0]):
+                                response = [dataclasses.asdict(x) for x in response[0]], response[1]
 
                         if view_func == f:
                             # we are in a request handler method


### PR DESCRIPTION
I tried to avoid using jsonify nor to create a dependency for Pydatinc. But I don't think that solution is ideal ... It just suits the problem without adding full support to Connexion or something like that.

My original Idea was to create a flag in order to be able to skip the make_response. But implementing that I realized that much more handy to have a proper Response after that decorator since the response is used to create the flags etc.