### PR TITLE
Add Request exceptions total to default metrics

### DIFF
--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -449,7 +449,7 @@ class PrometheusMetrics(object):
 
                 request_duration_labels = {
                     'method': request.method,
-                    'status': 500,
+                    'status': status_code,
                     duration_group_name: group
                 }
                 request_duration_labels.update(labels.values_for(response))

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -362,17 +362,18 @@ class PrometheusMetrics(object):
             **buckets_as_kwargs
         )
 
+        counter_labels = ('method', 'status') + labels.keys()
         request_total_metric = Counter(
             '%shttp_request_total' % prefix,
             'Total number of HTTP requests',
-            ('method', 'status') + labels.keys(),
+            counter_labels,
             registry=self.registry
         )
 
         request_exceptions_metric = Counter(
             '%shttp_request_exceptions_total' % prefix,
             'Total number of HTTP requests which resulted in an exception',
-            ('method', 'status') + labels.keys(),
+            counter_labels,
             registry=self.registry
         )
 

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -372,7 +372,7 @@ class PrometheusMetrics(object):
         request_exceptions_metric = Counter(
             '%shttp_request_exceptions_total' % prefix,
             'Total number of HTTP requests',
-            ('method', request.path, 'status') + labels.keys(),
+            ('method', 'path', 'status') + labels.keys(),
             registry=self.registry
         )
 
@@ -429,7 +429,7 @@ class PrometheusMetrics(object):
             request_exceptions_labels = {
                 'method': request.method,
                 'status': 500,
-                duration_group_name: group
+                'path': request.path,
             }
             request_exceptions_labels.update(labels.values_for(response))
             request_exceptions_metric.labels(**request_exceptions_labels).inc()

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -427,7 +427,8 @@ class PrometheusMetrics(object):
                 group = getattr(request, duration_group)
 
             # Check if the exception was raised using a response object and use
-            # its status_code if present. Otherwise assume it's a 500.
+            # its status_code if present. This will only work for ``werkzeug.exceptions.HTTPException``
+            # and subclasses thereof. Otherwise we assume it's a 500.
             try:
                 response = exception.get_response()
                 status_code = _to_status_code(response.status_code)

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -371,8 +371,8 @@ class PrometheusMetrics(object):
 
         request_exceptions_metric = Counter(
             '%shttp_request_exceptions_total' % prefix,
-            'Total number of HTTP requests',
-            ('method', duration_group_name, 'status') + labels.keys(),
+            'Total number of HTTP requests which resulted in an exception',
+            ('method', 'status') + labels.keys(),
             registry=self.registry
         )
 
@@ -435,14 +435,10 @@ class PrometheusMetrics(object):
             except:
                 status_code = 500
 
-            request_exceptions_labels = {
-                'method': request.method,
-                'status': status_code,
-                duration_group_name: group,
-            }
-            request_exceptions_labels.update(labels.values_for(response))
-
-            request_exceptions_metric.labels(**request_exceptions_labels).inc()
+            request_exceptions_metric.labels(
+                method=request.method, status=status_code,
+                **labels.values_for(response)
+            ).inc()
 
             if hasattr(request, 'prom_start_time'):
                 total_time = max(default_timer() - request.prom_start_time, 0)

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -438,6 +438,7 @@ class PrometheusMetrics(object):
                 duration_group_name: group,
             }
             request_exceptions_labels.update(labels.values_for(response))
+
             request_exceptions_metric.labels(**request_exceptions_labels).inc()
 
             if hasattr(request, 'prom_start_time'):

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -432,7 +432,7 @@ class PrometheusMetrics(object):
             try:
                 response = exception.get_response()
                 status_code = _to_status_code(response.status_code)
-            except AttributeError:
+            except:
                 status_code = 500
 
             request_exceptions_labels = {

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -420,13 +420,6 @@ class PrometheusMetrics(object):
                 if any(pattern.match(request.path) for pattern in self.excluded_paths):
                     return
 
-            response = make_response('Exception: %s' % exception, 500)
-
-            if callable(duration_group):
-                group = duration_group(request)
-            else:
-                group = getattr(request, duration_group)
-
             # Check if the exception was raised using a response object and use
             # its status_code if present. This will only work for ``werkzeug.exceptions.HTTPException``
             # and subclasses thereof. Otherwise we assume it's a 500.
@@ -435,6 +428,13 @@ class PrometheusMetrics(object):
                 status_code = _to_status_code(response.status_code)
             except:
                 status_code = 500
+            finally:
+                response = make_response('Exception: %s' % exception, status_code)
+
+            if callable(duration_group):
+                group = duration_group(request)
+            else:
+                group = getattr(request, duration_group)
 
             request_exceptions_metric.labels(
                 method=request.method, status=status_code,

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -426,6 +426,8 @@ class PrometheusMetrics(object):
             else:
                 group = getattr(request, duration_group)
 
+            # Check if the exception was raised using a response object and use
+            # its status_code if present. Otherwise assume it's a 500.
             try:
                 response = exception.get_response()
                 status_code = _to_status_code(response.status_code)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -114,6 +114,8 @@ class DefaultsTest(BaseTestCase):
         )
 
     def test_exception_counter_metric(self):
+        metrics = self.metrics()
+
         @self.app.route('/error')
         def test():
             abort(501)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,7 +1,7 @@
 from unittest_helper import BaseTestCase
 
 from prometheus_flask_exporter import NO_PREFIX
-from flask import request, make_response
+from flask import request, make_response, abort
 
 
 
@@ -119,13 +119,13 @@ class DefaultsTest(BaseTestCase):
 
         @self.app.route('/error')
         def test():
-            raise AttributeError
+            abort(501)
 
         self.client.get('/error')
 
         self.assertMetric(
             'flask_http_request_exceptions_total', '1.0',
-            ('method', 'GET'), ('path', '/error'), ('status', 200)
+            ('method', 'GET'), ('path', '/error'), ('status', 501)
         )
 
         self.client.get('/error')
@@ -133,7 +133,7 @@ class DefaultsTest(BaseTestCase):
 
         self.assertMetric(
             'flask_http_request_exceptions_total', '3.0',
-            ('method', 'GET'), ('path', '/error'), ('status', 200)
+            ('method', 'GET'), ('path', '/error'), ('status', 501)
         )
 
     def test_do_not_track_only_excludes_defaults(self):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -52,11 +52,10 @@ class DefaultsTest(BaseTestCase):
             'flask_http_request_duration_seconds_bucket', '2.0',
             ('le', '+Inf'), ('method', 'GET'), ('path', '/test'), ('status', 200)
         )
-        self.assertMetric(
-            'flask_http_request_exceptions_total', '0.0',
-            ('method', 'GET'), ('path', '/test'), ('status', 200)
+        self.assertAbsent(
+            'flask_http_request_exceptions_total',
+            ('method', 'GET'), ('path', '/skip/defaults'), ('status', 200)
         )
-
         self.client.get('/test')
 
         self.assertMetric(
@@ -163,7 +162,7 @@ class DefaultsTest(BaseTestCase):
         )
         self.assertAbsent(
             'flask_http_request_exceptions_total',
-            ('method', 'GET'), ('path', '/skip/defaults'), ('status', 200)
+            ('method', 'GET'), ('path', '/skip/defaults'),
         )
 
         self.assertMetric('cnt_before_total', 2.0)
@@ -213,9 +212,9 @@ class DefaultsTest(BaseTestCase):
             ('method', 'GET'), ('path', '/test'), ('status', 200),
             endpoint='/my-metrics'
         )
-        self.assertMetric(
-            'flask_http_request_exceptions_total', '0.0',
-            ('method', 'GET'), ('path', '/test'), ('status', 200),
+        self.assertAbsent(
+            'flask_http_request_exceptions_total',
+            ('method', 'GET'), ('path', '/test'),
             endpoint='/my-metrics'
         )
 
@@ -336,7 +335,10 @@ class DefaultsTest(BaseTestCase):
             'late_http_request_total',
             ('method', 'GET'), ('status', 200)
         )
-
+        self.assertAbsent(
+            'flask_http_request_exceptions_total',
+            ('method', 'GET'), ('path', '/test'),
+        )
         metrics.export_defaults(prefix='late')
 
         self.assertMetric(
@@ -356,9 +358,9 @@ class DefaultsTest(BaseTestCase):
             'late_http_request_duration_seconds_count', '3.0',
             ('method', 'GET'), ('path', '/test'), ('status', 200)
         )
-        self.assertMetric(
-            'late_http_request_exceptions_total', '0.0',
-            ('method', 'GET'), ('path', '/test'), ('status', 200)
+        self.assertAbsent(
+            'flask_http_request_exceptions_total',
+            ('method', 'GET'), ('path', '/test'),
         )
 
     def test_non_automatic_endpoint_registration(self):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -118,21 +118,26 @@ class DefaultsTest(BaseTestCase):
 
         @self.app.route('/error')
         def test():
-            abort(501)
+            raise AttributeError
 
-        self.client.get('/error')
+        try:
+            self.client.get('/error')
+        except AttributeError:
+            pass
 
         self.assertMetric(
             'flask_http_request_exceptions_total', '1.0',
-            ('method', 'GET'), ('path', '/error'), ('status', 501)
+            ('method', 'GET'), ('path', '/error'), ('status', 500)
         )
 
-        self.client.get('/error')
-        self.client.get('/error')
+        try:
+            self.client.get('/error')
+        except AttributeError:
+            pass
 
         self.assertMetric(
-            'flask_http_request_exceptions_total', '3.0',
-            ('method', 'GET'), ('path', '/error'), ('status', 501)
+            'flask_http_request_exceptions_total', '2.0',
+            ('method', 'GET'), ('path', '/error'), ('status', 500)
         )
 
     def test_do_not_track_only_excludes_defaults(self):

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -4,7 +4,6 @@ from prometheus_flask_exporter import NO_PREFIX
 from flask import request, make_response, abort
 
 
-
 class DefaultsTest(BaseTestCase):
     def test_simple(self):
         metrics = self.metrics()
@@ -115,8 +114,6 @@ class DefaultsTest(BaseTestCase):
         )
 
     def test_exception_counter_metric(self):
-        self.metrics(export_defaults=False)
-
         @self.app.route('/error')
         def test():
             abort(501)

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -54,7 +54,7 @@ class DefaultsTest(BaseTestCase):
             ('le', '+Inf'), ('method', 'GET'), ('path', '/test'), ('status', 200)
         )
         self.assertMetric(
-            'flask_http_request_exceptions', '0.0',
+            'flask_http_request_exceptions_total', '0.0',
             ('method', 'GET'), ('path', '/test'), ('status', 200)
         )
 
@@ -119,12 +119,12 @@ class DefaultsTest(BaseTestCase):
 
         @self.app.route('/error')
         def test():
-            raise RuntimeError
+            raise AttributeError
 
         self.client.get('/error')
 
         self.assertMetric(
-            'flask_http_request_exceptions', '0.0',
+            'flask_http_request_exceptions_total', '1.0',
             ('method', 'GET'), ('path', '/error'), ('status', 200)
         )
 
@@ -132,7 +132,7 @@ class DefaultsTest(BaseTestCase):
         self.client.get('/error')
 
         self.assertMetric(
-            'flask_http_request_exceptions', '3.0',
+            'flask_http_request_exceptions_total', '3.0',
             ('method', 'GET'), ('path', '/error'), ('status', 200)
         )
 


### PR DESCRIPTION
Counts exceptions arriving at ``teardown_request``.

It currently does not allow tracking further http codes in range of 405-5xx

I looked at adding the counter in the decorator function, as that would've allowed
counting all sorts of other exceptions, but that would've dirtied design.

Finally, I just wasn't sure what kind of exception to expect here - are these always unhandled ones?
Or could they also be other `5xx` HTTP exceptions? Do 4xx exceptions arrive here at all (only confident that `404`s do not show up here)?

Perhaps you have some insight on this.
