### PR TITLE
Support sending the OpenMetrics format when asked

### DIFF
--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -12,7 +12,7 @@ from flask import Flask, Response
 from flask.views import MethodViewType
 from werkzeug.serving import is_running_from_reloader
 from prometheus_client import Counter, Histogram, Gauge, Summary
-from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+from prometheus_client.exposition import choose_encoder
 
 if sys.version_info[0:2] >= (3, 4):
     # Python v3.4+ has a built-in has __wrapped__ attribute
@@ -265,7 +265,8 @@ class PrometheusMetrics(object):
             if 'prometheus_multiproc_dir' in os.environ:
                 multiprocess.MultiProcessCollector(registry)
 
-            headers = {'Content-Type': CONTENT_TYPE_LATEST}
+            generate_latest, content_type = choose_encoder(request.headers.get("Accept"))
+            headers = {'Content-Type': content_type}
             return generate_latest(registry), 200, headers
 
     def start_http_server(self, port, host='0.0.0.0', endpoint='/metrics'):


### PR DESCRIPTION
Recent `prometheus_client` versions (v0.4.1 and later, released in October 2018) support sending the new OpenMetrics format when clients negotiate for it via the HTTP `Accept` header. This PR makes use of this functionality.

You can verify that it is working by sending the correct header:

```console
$ curl -vs -H "Accept: application/openmetrics-text" http://localhost:5000/metrics
> GET /metrics HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.58.0
> Accept: application/openmetrics-text
>
< HTTP/1.0 200 OK
< Content-Type: application/openmetrics-text; version=0.0.1; charset=utf-8
< Content-Length: 6083
< Server: Werkzeug/1.0.1 Python/3.6.9
< Date: Wed, 02 Sep 2020 15:34:15 GMT
...
```

Versus the default:
```console
$ curl -vs http://localhost:5000/metrics
> GET /metrics HTTP/1.1
> Host: localhost:5000
> User-Agent: curl/7.58.0
> Accept: */*
>
< HTTP/1.0 200 OK
< Content-Type: text/plain; version=0.0.4; charset=utf-8
< Content-Length: 6400
< Server: Werkzeug/1.0.1 Python/3.6.9
< Date: Wed, 02 Sep 2020 15:33:27 GMT
...
```