### PR TITLE
Update env var to `PROMETHEUS_MULTIPROC_DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ This should return `True` on one process only, and the underlying
 [Prometheus client library](https://github.com/prometheus/client_python)
 will collect the metrics for all the forked children or siblings.
 
-__Note:__ this needs the `prometheus_multiproc_dir` environment variable
+__Note:__ this needs the `PROMETHEUS_MULTIPROC_DIR` environment variable
 to point to a valid, writable directory.
 
 You'll also have to call the `metrics.start_http_server()` function

--- a/examples/gunicorn-app-factory/Dockerfile
+++ b/examples/gunicorn-app-factory/Dockerfile
@@ -12,6 +12,6 @@ ADD examples/gunicorn-app-factory/server.py \
     /var/flask/
 WORKDIR /var/flask
 
-ENV prometheus_multiproc_dir /tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 
 CMD gunicorn -c config.py -w 4 -b 0.0.0.0:4000 server:app

--- a/examples/gunicorn-app-factory/Dockerfile
+++ b/examples/gunicorn-app-factory/Dockerfile
@@ -13,5 +13,6 @@ ADD examples/gunicorn-app-factory/server.py \
 WORKDIR /var/flask
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV prometheus_multiproc_dir /tmp
 
 CMD gunicorn -c config.py -w 4 -b 0.0.0.0:4000 server:app

--- a/examples/gunicorn-internal/Dockerfile
+++ b/examples/gunicorn-internal/Dockerfile
@@ -9,6 +9,6 @@ RUN pip install -e /tmp/latest --upgrade
 ADD examples/gunicorn-internal/server.py examples/gunicorn-internal/config.py /var/flask/
 WORKDIR /var/flask
 
-ENV prometheus_multiproc_dir /tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 
 CMD gunicorn -c config.py -w 4 -b 0.0.0.0:4000 server:app

--- a/examples/gunicorn-internal/Dockerfile
+++ b/examples/gunicorn-internal/Dockerfile
@@ -10,5 +10,6 @@ ADD examples/gunicorn-internal/server.py examples/gunicorn-internal/config.py /v
 WORKDIR /var/flask
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV prometheus_multiproc_dir /tmp
 
 CMD gunicorn -c config.py -w 4 -b 0.0.0.0:4000 server:app

--- a/examples/gunicorn/Dockerfile
+++ b/examples/gunicorn/Dockerfile
@@ -10,6 +10,7 @@ ADD examples/gunicorn/server.py examples/gunicorn/config.py /var/flask/
 WORKDIR /var/flask
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV prometheus_multiproc_dir /tmp
 ENV METRICS_PORT 9200
 
 CMD gunicorn -c config.py -w 4 -b 0.0.0.0:4000 server:app

--- a/examples/gunicorn/Dockerfile
+++ b/examples/gunicorn/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install -e /tmp/latest --upgrade
 ADD examples/gunicorn/server.py examples/gunicorn/config.py /var/flask/
 WORKDIR /var/flask
 
-ENV prometheus_multiproc_dir /tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 ENV METRICS_PORT 9200
 
 CMD gunicorn -c config.py -w 4 -b 0.0.0.0:4000 server:app

--- a/examples/pytest-app-factory/Dockerfile
+++ b/examples/pytest-app-factory/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install flask pytest
 ADD . /tmp/latest
 RUN pip install -e /tmp/latest --upgrade
 
-ENV prometheus_multiproc_dir=/tmp
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp
 ENV PYTHONPATH=/data
 
 ADD ./examples/pytest-app-factory /data

--- a/examples/pytest-app-factory/Dockerfile
+++ b/examples/pytest-app-factory/Dockerfile
@@ -5,7 +5,7 @@ RUN pip install flask pytest
 ADD . /tmp/latest
 RUN pip install -e /tmp/latest --upgrade
 
-ENV PROMETHEUS_MULTIPROC_DIR=/tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 ENV prometheus_multiproc_dir /tmp
 ENV PYTHONPATH=/data
 

--- a/examples/pytest-app-factory/Dockerfile
+++ b/examples/pytest-app-factory/Dockerfile
@@ -6,6 +6,7 @@ ADD . /tmp/latest
 RUN pip install -e /tmp/latest --upgrade
 
 ENV PROMETHEUS_MULTIPROC_DIR=/tmp
+ENV prometheus_multiproc_dir /tmp
 ENV PYTHONPATH=/data
 
 ADD ./examples/pytest-app-factory /data

--- a/examples/uwsgi-connexion/Dockerfile
+++ b/examples/uwsgi-connexion/Dockerfile
@@ -10,7 +10,7 @@ RUN pip install -e /tmp/latest --upgrade
 ADD examples/uwsgi-connexion /var/flask
 WORKDIR /var/flask
 
-ENV prometheus_multiproc_dir /tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 ENV METRICS_PORT 9200
 
 CMD uwsgi --http 0.0.0.0:4000 --module main:app --master --processes 4 --threads 2

--- a/examples/uwsgi-connexion/Dockerfile
+++ b/examples/uwsgi-connexion/Dockerfile
@@ -11,6 +11,7 @@ ADD examples/uwsgi-connexion /var/flask
 WORKDIR /var/flask
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV prometheus_multiproc_dir /tmp
 ENV METRICS_PORT 9200
 
 CMD uwsgi --http 0.0.0.0:4000 --module main:app --master --processes 4 --threads 2

--- a/examples/uwsgi-lazy-apps/Dockerfile
+++ b/examples/uwsgi-lazy-apps/Dockerfile
@@ -12,5 +12,6 @@ ADD examples/uwsgi-lazy-apps/server.py /var/flask/
 WORKDIR /var/flask
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV prometheus_multiproc_dir /tmp
 
 CMD uwsgi --http 0.0.0.0:4000 --module server:app --master --processes 4 --threads 2 --lazy-apps

--- a/examples/uwsgi-lazy-apps/Dockerfile
+++ b/examples/uwsgi-lazy-apps/Dockerfile
@@ -11,6 +11,6 @@ RUN pip install -e /tmp/latest --upgrade
 ADD examples/uwsgi-lazy-apps/server.py /var/flask/
 WORKDIR /var/flask
 
-ENV prometheus_multiproc_dir /tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 
 CMD uwsgi --http 0.0.0.0:4000 --module server:app --master --processes 4 --threads 2 --lazy-apps

--- a/examples/uwsgi/Dockerfile
+++ b/examples/uwsgi/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install -e /tmp/latest --upgrade
 ADD examples/uwsgi/server.py /var/flask/
 WORKDIR /var/flask
 
-ENV prometheus_multiproc_dir /tmp
+ENV PROMETHEUS_MULTIPROC_DIR /tmp
 ENV METRICS_PORT 9200
 
 CMD uwsgi --http 0.0.0.0:4000 --module server:app --master --processes 4 --threads 2

--- a/examples/uwsgi/Dockerfile
+++ b/examples/uwsgi/Dockerfile
@@ -12,6 +12,7 @@ ADD examples/uwsgi/server.py /var/flask/
 WORKDIR /var/flask
 
 ENV PROMETHEUS_MULTIPROC_DIR /tmp
+ENV prometheus_multiproc_dir /tmp
 ENV METRICS_PORT 9200
 
 CMD uwsgi --http 0.0.0.0:4000 --module server:app --master --processes 4 --threads 2

--- a/examples/wsgi/wsgi.py
+++ b/examples/wsgi/wsgi.py
@@ -3,6 +3,6 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-os.environ["prometheus_multiproc_dir"] = "/tmp"
+os.environ["PROMETHEUS_MULTIPROC_DIR"] = "/tmp"
 
 from app import app as application

--- a/examples/wsgi/wsgi.py
+++ b/examples/wsgi/wsgi.py
@@ -4,5 +4,6 @@ import sys
 sys.path.insert(0, os.path.dirname(__file__))
 
 os.environ["PROMETHEUS_MULTIPROC_DIR"] = "/tmp"
+os.environ["prometheus_multiproc_dir"] = "/tmp"
 
 from app import app as application

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -257,7 +257,7 @@ class PrometheusMetrics(object):
             # import these here so they don't clash with our own multiprocess module
             from prometheus_client import multiprocess, CollectorRegistry
 
-            if 'prometheus_multiproc_dir' in os.environ:
+            if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
                 registry = CollectorRegistry()
             else:
                 registry = self.registry
@@ -265,7 +265,7 @@ class PrometheusMetrics(object):
             if 'name[]' in request.args:
                 registry = registry.restricted_registry(request.args.getlist('name[]'))
 
-            if 'prometheus_multiproc_dir' in os.environ:
+            if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
                 multiprocess.MultiProcessCollector(registry)
 
             generate_latest, content_type = choose_encoder(request.headers.get("Accept"))

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -257,7 +257,7 @@ class PrometheusMetrics(object):
             # import these here so they don't clash with our own multiprocess module
             from prometheus_client import multiprocess, CollectorRegistry
 
-            if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+            if 'PROMETHEUS_MULTIPROC_DIR' in os.environ or 'prometheus_multiproc_dir' in os.environ:
                 registry = CollectorRegistry()
             else:
                 registry = self.registry
@@ -265,7 +265,7 @@ class PrometheusMetrics(object):
             if 'name[]' in request.args:
                 registry = registry.restricted_registry(request.args.getlist('name[]'))
 
-            if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+            if 'PROMETHEUS_MULTIPROC_DIR' in os.environ or 'prometheus_multiproc_dir' in os.environ:
                 multiprocess.MultiProcessCollector(registry)
 
             generate_latest, content_type = choose_encoder(request.headers.get("Accept"))

--- a/prometheus_flask_exporter/multiprocess.py
+++ b/prometheus_flask_exporter/multiprocess.py
@@ -21,8 +21,12 @@ def _check_multiproc_env_var():
     if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
         if os.path.isdir(os.environ['PROMETHEUS_MULTIPROC_DIR']):
             return
+    elif 'prometheus_multiproc_dir' in os.environ:
+        if os.path.isdir(os.environ['prometheus_multiproc_dir']):
+            return
 
-    raise ValueError('env PROMETHEUS_MULTIPROC_DIR is not set or not a directory')
+    raise ValueError('one of env PROMETHEUS_MULTIPROC_DIR or env prometheus_multiproc_dir' +
+        'must be set and be a directory')
 
 
 class MultiprocessPrometheusMetrics(PrometheusMetrics):

--- a/prometheus_flask_exporter/multiprocess.py
+++ b/prometheus_flask_exporter/multiprocess.py
@@ -11,18 +11,18 @@ from . import PrometheusMetrics
 
 def _check_multiproc_env_var():
     """
-    Checks that the `prometheus_multiproc_dir` environment variable is set,
+    Checks that the `PROMETHEUS_MULTIPROC_DIR` environment variable is set,
     which is required for the multiprocess collector to work properly.
 
     :raises ValueError: if the environment variable is not set
         or if it does not point to a directory
     """
 
-    if 'prometheus_multiproc_dir' in os.environ:
-        if os.path.isdir(os.environ['prometheus_multiproc_dir']):
+    if 'PROMETHEUS_MULTIPROC_DIR' in os.environ:
+        if os.path.isdir(os.environ['PROMETHEUS_MULTIPROC_DIR']):
             return
 
-    raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
+    raise ValueError('env PROMETHEUS_MULTIPROC_DIR is not set or not a directory')
 
 
 class MultiprocessPrometheusMetrics(PrometheusMetrics):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -21,6 +21,9 @@ class ExtensionsTest(BaseTestCase):
         if 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
             os.environ['PROMETHEUS_MULTIPROC_DIR'] = '/tmp'
             self._multiproc_dir_added = True
+        elif 'prometheus_multiproc_dir' not in os.environ:
+            os.environ['prometheus_multiproc_dir'] = '/tmp'
+            self._multiproc_dir_added = True
         else:
             self._multiproc_dir_added = False
 
@@ -42,6 +45,7 @@ class ExtensionsTest(BaseTestCase):
     def tearDown(self):
         if self._multiproc_dir_added:
             del os.environ['PROMETHEUS_MULTIPROC_DIR']
+            del os.environ['prometheus_multiproc_dir']
 
     def test_with_defaults(self):
         for extension_type in self._all_extensions:

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -18,8 +18,8 @@ class ExtensionsTest(BaseTestCase):
     def setUp(self):
         super(ExtensionsTest, self).setUp()
 
-        if 'prometheus_multiproc_dir' not in os.environ:
-            os.environ['prometheus_multiproc_dir'] = '/tmp'
+        if 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
+            os.environ['PROMETHEUS_MULTIPROC_DIR'] = '/tmp'
             self._multiproc_dir_added = True
         else:
             self._multiproc_dir_added = False
@@ -41,7 +41,7 @@ class ExtensionsTest(BaseTestCase):
 
     def tearDown(self):
         if self._multiproc_dir_added:
-            del os.environ['prometheus_multiproc_dir']
+            del os.environ['PROMETHEUS_MULTIPROC_DIR']
 
     def test_with_defaults(self):
         for extension_type in self._all_extensions:


### PR DESCRIPTION
Issue: https://github.com/rycus86/prometheus_flask_exporter/issues/97

This PR changes all occurrences of `prometheus_multiproc_dir` to `PROMETHEUS_MULTIPROC_DIR` following `v0.10.0` release of `prometheus/client_python`: https://github.com/prometheus/client_python/releases/tag/v0.10.0