### PR TITLE
Fix to newest prometheus_client breaks compatibility with choose_encoder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 flask
-prometheus_client
+prometheus_client==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
-    install_requires=['prometheus_client', 'flask'],
+    install_requires=['prometheus_client==0.13.1', 'flask'],
 )


### PR DESCRIPTION
Newest prometheus_client 0.14 breaks compatibility (choose_encoder was removed) 
For a quick fix explicitly select prometheus_client==0.13.1 in the requirements and setup.py
