### PR TITLE
refactor: Remove legacy `object` use in classes and legacy `super()` call pattern

### DIFF
--- a/examples/gunicorn-multiprocess-109/server.py
+++ b/examples/gunicorn-multiprocess-109/server.py
@@ -33,7 +33,7 @@ class StandaloneApplication(gunicorn.app.base.BaseApplication):
         return self.application
 
 
-class CustomCollector(object):
+class CustomCollector:
     def collect(self):
         info = InfoMetricFamily('xxxx', 'xxxxxx')
         info.add_metric(labels='version',

--- a/examples/pytest-app-factory/myapp/config.py
+++ b/examples/pytest-app-factory/myapp/config.py
@@ -4,7 +4,7 @@ from .extensions import setup_extensions, metrics
 metrics.info('app_info', 'Sample app', version='0.1.2')
 
 
-class TestConfig(object):
+class TestConfig:
     DEBUG = False
     TESTING = True
 

--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -57,7 +57,7 @@ documentation (see: https://prometheus.io/docs/concepts/data_model/#metric-names
 """
 
 
-class PrometheusMetrics(object):
+class PrometheusMetrics:
     """
     Prometheus metrics export configuration for Flask.
 
@@ -793,7 +793,7 @@ class PrometheusMetrics(object):
             else:
                 return lambda x: f()
 
-        class CombinedLabels(object):
+        class CombinedLabels:
             def __init__(self, _labels):
                 self.labels = _labels.items()
 
@@ -940,7 +940,7 @@ class ConnexionPrometheusMetrics(PrometheusMetrics):
         if 'response_converter' not in kwargs:
             kwargs['response_converter'] = self._create_response_converter(default_mimetype)
 
-        super(ConnexionPrometheusMetrics, self).__init__(flask_app, **kwargs)
+        super().__init__(flask_app, **kwargs)
 
     @staticmethod
     def content_type(content_type):
@@ -990,7 +990,7 @@ class RESTfulPrometheusMetrics(PrometheusMetrics):
 
         if api and 'response_converter' not in kwargs:
             kwargs['response_converter'] = self._create_response_converter(api)
-        super(RESTfulPrometheusMetrics, self).__init__(app, **kwargs)
+        super().__init__(app, **kwargs)
 
     @classmethod
     def for_app_factory(cls, api=None, **kwargs):
@@ -999,7 +999,7 @@ class RESTfulPrometheusMetrics(PrometheusMetrics):
     def init_app(self, app, api=None):
         if api:
             self._response_converter = self._create_response_converter(api)
-        return super(RESTfulPrometheusMetrics, self).init_app(app)
+        return super().init_app(app)
 
     @staticmethod
     def _create_response_converter(api):

--- a/prometheus_flask_exporter/multiprocess.py
+++ b/prometheus_flask_exporter/multiprocess.py
@@ -59,7 +59,7 @@ class MultiprocessPrometheusMetrics(PrometheusMetrics):
 
         kwargs.pop('path', None)  # remove the path parameter if it was passed in
 
-        super(MultiprocessPrometheusMetrics, self).__init__(
+        super().__init__(
             app=app, path=None, registry=registry, **kwargs
         )
 
@@ -107,7 +107,7 @@ class MultiprocessInternalPrometheusMetrics(MultiprocessPrometheusMetrics):
         Create a new multiprocess-aware Prometheus metrics export configuration.
         """
 
-        super(MultiprocessInternalPrometheusMetrics, self).__init__(app=app, **kwargs)
+        super().__init__(app=app, **kwargs)
 
         if app:
             self.register_endpoint(path)
@@ -220,7 +220,7 @@ class GunicornInternalPrometheusMetrics(GunicornPrometheusMetrics):
         Create a new multiprocess-aware Prometheus metrics export configuration.
         """
 
-        super(GunicornInternalPrometheusMetrics, self).__init__(app=app, **kwargs)
+        super().__init__(app=app, **kwargs)
 
         if app:
             self.register_endpoint(path)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -361,7 +361,7 @@ class EndpointTest(BaseTestCase):
     def test_excluded_endpoints(self):
         self.metrics(excluded_paths='/exc')
 
-        class RequestCounter(object):
+        class RequestCounter:
             value = 0
 
         @self.app.route('/included')
@@ -400,7 +400,7 @@ class EndpointTest(BaseTestCase):
             '/exc/t.*'
         ])
 
-        class RequestCounter(object):
+        class RequestCounter:
             value = 0
 
         @self.app.route('/included')

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -16,7 +16,7 @@ from unittest_helper import BaseTestCase
 
 class ExtensionsTest(BaseTestCase):
     def setUp(self):
-        super(ExtensionsTest, self).setUp()
+        super().setUp()
 
         if 'PROMETHEUS_MULTIPROC_DIR' not in os.environ:
             os.environ['PROMETHEUS_MULTIPROC_DIR'] = '/tmp'
@@ -59,7 +59,7 @@ class ExtensionsTest(BaseTestCase):
                 kwargs = {}
 
                 if extension_type is ConnexionPrometheusMetrics:
-                    class WrappedApp(object):
+                    class WrappedApp:
                         def __init__(self, app):
                             self.app = app
 
@@ -77,7 +77,7 @@ class ExtensionsTest(BaseTestCase):
 
     def test_with_registry(self):
         for extension_type in self._all_extensions:
-            class MockRegistry(object):
+            class MockRegistry:
                 def register(self, *arg, **kwargs):
                     pass
 

--- a/tests/unittest_helper.py
+++ b/tests/unittest_helper.py
@@ -10,7 +10,7 @@ from prometheus_flask_exporter import PrometheusMetrics
 
 class BaseTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
-        super(BaseTestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if sys.version_info.major < 3:
             self.assertRegex = self.assertRegexpMatches
             self.assertNotRegex = self.assertNotRegexpMatches


### PR DESCRIPTION
This merge request makes two changes:

1. Removes the use of `object` as a subclass in classes as this is only for Python 2. This was to address the old style classes from Python 2 and does not exist in Python 3. See https://www.python.org/doc/newstyle/ for additional details.
2. This updates the way that `super` is used to avoid the various arguments and to take advantage of how this works by default in modern versions of Python 3, as outlined on https://docs.python.org/3/library/functions.html#super

Additional adjustments to formatting behaviors in the tests module is possible, these will be evaluated after this.

Changes were detected using the [`pyupgrade`](https://github.com/asottile/pyupgrade) tool with a 3.7 target. 