### PR TITLE
Update README.md with a important information about the app factory u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ metrics = PrometheusMetrics.for_app_factory()
 # then later:
 metrics.init_app(app)
 ```
+**NOTE**: When using the Flask application in debug mode, you must set the `DEBUG_METRICS` environment variable to `1` before starting the application to ensure the `/metrics` endpoint is exposed:
+
+```bash
+export DEBUG_METRICS=1
+```
+This step is crucial because, without it, the `/metrics` endpoint might not be properly registered and displayed in debug mode.
 
 ## Securing the metrics endpoint
 


### PR DESCRIPTION
Took some time and testing to got this and one only after some testing found that is needed export the variable DEBUG_METRICS, this is a update suggestion on the README to help other if they found the same issue when testing the export using App Fabric Pattern.

Bellow the specific log message, only showed for me after make some specific testings and comparing results, outputs, maybe a enhacement on the future is make this message more clear when using the function for_app_factory()


```bash
 * Detected change in '//flask_hello_world/examples/flask_test_prometheus.py', reloading
 * Restarting with stat
[2024-04-20 11:08:01,540] DEBUG in __init__: Metrics are disabled when run in the Flask development server with reload enabled. Set the environment variable DEBUG_METRICS=1 to enable them anyway.
 * Debugger is active!
 * Debugger PIN: 325-243-250

```