### PR TITLE
Allow to measure async views

### DIFF
--- a/prometheus_flask_exporter/__init__.py
+++ b/prometheus_flask_exporter/__init__.py
@@ -715,7 +715,7 @@ class PrometheusMetrics:
                 try:
                     try:
                         # execute the handler function
-                        response = f(*args, **kwargs)
+                        response = current_app.ensure_sync(f)(*args, **kwargs)
                     except Exception as ex:
                         # let Flask decide to wrap or reraise the Exception
                         response = current_app.handle_user_exception(ex)


### PR DESCRIPTION
Following the flask cookbook (https://flask.palletsprojects.com/en/stable/async-await/#extensions), this MR enables measuring async views.

Fixes rycus86/prometheus_flask_exporter#183