### PR TITLE
Update sample-signal example prometheus and grafana docker images

### DIFF
--- a/examples/sample-signals/docker-compose.yml
+++ b/examples/sample-signals/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   # the Prometheus server
   prometheus:
     container_name: prometheus
-    image: prom/prometheus:v2.2.1
+    image: prom/prometheus:v2.53.4
     volumes:
       - ./prometheus/config.yml:/etc/prometheus/prometheus.yml
     depends_on:
@@ -27,7 +27,7 @@ services:
 
   # Grafana for visualization
   grafana:
-    image: grafana/grafana:5.1.0
+    image: grafana/grafana:11.5.3
     volumes:
       - ./grafana/config.ini:/etc/grafana/grafana.ini
       - ./grafana/datasource.yaml:/etc/grafana/provisioning/datasources/default.yaml


### PR DESCRIPTION
The sample-signal example displays a [DEPRECATION NOTICE] when running `docker compose up -d` and stops the container from running

> [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/prom/prometheus:v2.2.1 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

This PR updates the prom/prometheus from v2.2.1 to latest LTS v2.53.4 to fix the deprecation issue and also updates the grafana/grafana 5.1.0 to latest 11.5.3

Running the sample-signal app now works and the grafana dashboard displays correctly